### PR TITLE
Do not `sudo` with `make docker`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,6 @@ clean:
 
 docker:
 	docker build -t switchmode .
-	docker run -v $(shell pwd)/$(OUTPUT):/workdir/$(OUTPUT) switchmode
-	sudo chown -R `whoami`:`whoami` $(OUTPUT)
+	docker run --name switchmode switchmode
+	docker cp switchmode:/workdir/$(OUTPUT) $(OUTPUT)
+	docker rm switchmode


### PR DESCRIPTION
I think it is much better simply `docker cp` the build output dir
instead of using a read/write volume (read-only volumes are great, but
volumes on the host with a write access from a container are a source
of headaches).

Moreover, the container is removed after the operation.