### PR TITLE
Clarify project statement forms

### DIFF
--- a/projects/closed-development-flat.cform
+++ b/projects/closed-development-flat.cform
@@ -8,7 +8,7 @@
 
         \\  <Developer> will develop software with the following functionality: [Software Functionality]
 
-        \\  The software will meet the following compatibility and other technical criteria: [Software Description]
+        \\  The software will meet the following compatibility and other technical criteria: [Technical Criteria]
 
         \\  <Developer> will work to ensure publication of initial working versions by [Initial Deadline] and final versions by [Final Deadline].
 

--- a/projects/closed-development-flat.cform
+++ b/projects/closed-development-flat.cform
@@ -6,10 +6,12 @@
 
     \Service\
 
-        \\  <Developer> will develop and publish software to [Software Description]
+        \\  <Developer> will develop software to [Software Description]
 
         \\  The software will meet the following compatibility and other technical criteria: [Software Description]
 
         \\  <Developer> will work to ensure publication of initial working versions by [Initial Deadline] and final versions by [Final Deadline].
+
+    \Delivery\  <Developer> will deliver work on the project to <Company> by [Delivery Method].
 
     \Fees\  <Company> will pay <Developer> a flat fee of [Flat Fee].

--- a/projects/closed-development-flat.cform
+++ b/projects/closed-development-flat.cform
@@ -6,7 +6,7 @@
 
     \Service\
 
-        \\  <Developer> will develop software to [Software Description]
+        \\  <Developer> will develop software with the following functionality: [Software Functionality]
 
         \\  The software will meet the following compatibility and other technical criteria: [Software Description]
 

--- a/projects/closed-development-hourly.cform
+++ b/projects/closed-development-hourly.cform
@@ -8,7 +8,7 @@
 
         \\  <Developer> will develop software with the following functionality: [Software Functionality]
 
-        \\  The software will meet the following compatibility and other technical criteria: [Software Description]
+        \\  The software will meet the following compatibility and other technical criteria: [Technical Criteria]
 
         \\  <Developer> will work to ensure publication of initial working versions by [Initial Deadline] and final versions by [Final Deadline].
 

--- a/projects/closed-development-hourly.cform
+++ b/projects/closed-development-hourly.cform
@@ -6,7 +6,7 @@
 
     \Service\
 
-        \\  <Developer> will develop software to [Software Description]
+        \\  <Developer> will develop software with the following functionality: [Software Functionality]
 
         \\  The software will meet the following compatibility and other technical criteria: [Software Description]
 

--- a/projects/closed-development-hourly.cform
+++ b/projects/closed-development-hourly.cform
@@ -6,10 +6,12 @@
 
     \Service\
 
-        \\  <Developer> will develop and publish software to [Software Description]
+        \\  <Developer> will develop software to [Software Description]
 
         \\  The software will meet the following compatibility and other technical criteria: [Software Description]
 
         \\  <Developer> will work to ensure publication of initial working versions by [Initial Deadline] and final versions by [Final Deadline].
+
+    \Delivery\  <Developer> will deliver work on the project to <Company> by [Delivery Method].
 
     \Fees\  <Company> will pay <Developer> [Hourly Rate] per hour, in fairly rounded quarter-hour increments.

--- a/projects/open-development-flat.cform
+++ b/projects/open-development-flat.cform
@@ -8,7 +8,7 @@
 
         \\  <Developer> will develop software with the following functionality: [Software Functionality]
 
-        \\  The software will meet the following compatibility and other technical criteria: [Software Description]
+        \\  The software will meet the following compatibility and other technical criteria: [Technical Criteria]
 
         \\  <Developer> will work to ensure publication of initial working versions by [Initial Deadline] and final versions by [Final Deadline].
 

--- a/projects/open-development-flat.cform
+++ b/projects/open-development-flat.cform
@@ -6,10 +6,12 @@
 
     \Service\
 
-        \\  <Developer> will develop and publish software to [Software Description]
+        \\  <Developer> will develop software to [Software Description]
 
         \\  The software will meet the following compatibility and other technical criteria: [Software Description]
 
         \\  <Developer> will work to ensure publication of initial working versions by [Initial Deadline] and final versions by [Final Deadline].
+
+    \Delivery\  <Developer> will deliver work on the project to <Company> by [Delivery Method].
 
     \Fees\  <Company> will pay <Developer> a flat fee of [Flat Fee].

--- a/projects/open-development-flat.cform
+++ b/projects/open-development-flat.cform
@@ -6,7 +6,7 @@
 
     \Service\
 
-        \\  <Developer> will develop software to [Software Description]
+        \\  <Developer> will develop software with the following functionality: [Software Functionality]
 
         \\  The software will meet the following compatibility and other technical criteria: [Software Description]
 

--- a/projects/open-development-hourly.cform
+++ b/projects/open-development-hourly.cform
@@ -8,7 +8,7 @@
 
         \\  <Developer> will develop software with the following functionality: [Software Functionality]
 
-        \\  The software will meet the following compatibility and other technical criteria: [Software Description]
+        \\  The software will meet the following compatibility and other technical criteria: [Technical Criteria]
 
         \\  <Developer> will work to ensure publication of initial working versions by [Initial Deadline] and final versions by [Final Deadline].
 

--- a/projects/open-development-hourly.cform
+++ b/projects/open-development-hourly.cform
@@ -6,7 +6,7 @@
 
     \Service\
 
-        \\  <Developer> will develop software to [Software Description]
+        \\  <Developer> will develop software with the following functionality: [Software Functionality]
 
         \\  The software will meet the following compatibility and other technical criteria: [Software Description]
 

--- a/projects/open-development-hourly.cform
+++ b/projects/open-development-hourly.cform
@@ -6,10 +6,12 @@
 
     \Service\
 
-        \\  <Developer> will develop and publish software to [Software Description]
+        \\  <Developer> will develop software to [Software Description]
 
         \\  The software will meet the following compatibility and other technical criteria: [Software Description]
 
         \\  <Developer> will work to ensure publication of initial working versions by [Initial Deadline] and final versions by [Final Deadline].
+
+    \Delivery\  <Developer> will deliver work on the project to <Company> by [Delivery Method].
 
     \Fees\  <Company> will pay <Developer> [Hourly Rate] per hour, in fairly rounded quarter-hour increments.


### PR DESCRIPTION
This PR moves terms about how to deliver programming work from the master terms into the project summaries. I think that makes sense, since not all projects will involve code deliveries, and clients will often want more detail on delivery, such as whether the developer will provide only the final product, or a revision control repository.

This PR also slightly expands and hopefully clarifies the blanks about software functionality and technical standards on project summaries.