### PR TITLE
README: Update Common Form link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 an open form contract for open source contractors
 
-Download the most recent release from [GitHub](https://github.com/switchmode/switchmode/releases) or [commonform.org](https://commonform.org/publishers/switchmode).
+Download the most recent release from [GitHub](https://github.com/switchmode/switchmode/releases) or [commonform.org](https://commonform.org/switchmode).
 
 ## Be Warned!
 


### PR DESCRIPTION
The prior URL is 404ing as of now.

A better #17. Unlike that one, which aimed at the form under the `kemitchell` publisher, this aims back at the publisher page for the organization `switchmode`.