### PR TITLE
Add Cost of Collection

### DIFF
--- a/agreement.cform
+++ b/agreement.cform
@@ -28,6 +28,8 @@
 
         \Late Payment\  <Company> agrees to pay <Developer> [Late Payment Interest] interest on late bill payments, compounded monthly.  If the law sets a lower maximum rate of late-payment interest, <Company> agrees to pay that rate of interest instead.  If <Company> fails to pay any bill on time, <Developer> may give <Notice> and stop any or all work under this agreement until all bills due are paid and all suspected errors are addressed.  Stopping work in this way postpones all deadlines under each <Project> for as long as work stops.  Retainer and other recurring fees continue to add up.
 
+        \Cost of Collection\  If <Company> fails to pay any bill on time, <Company> agrees to pay <Developer> costs of pursuing payment and collecting that bill, such as attorney fees and costs, that <Developer> incurs after the deadline for payment.
+
         \Delivery\  <Developer> will deliver work on the <Project> to <Company> by sending the <Technical Representative> copies or Internet addresses from which to download copies.
 
         \Intellectual Property\


### PR DESCRIPTION
This PR adds a new section that obligates the customer to pay costs of collection for overdue bills, as long as the expenses rack up _after_ the bill becomes overdue.

An alternative here would be to include a general "English rule" or "loser pays" rule for all attorney fees, and so on.